### PR TITLE
Expand kangaroo distance to 256 bits

### DIFF
--- a/Backup.cpp
+++ b/Backup.cpp
@@ -230,7 +230,7 @@ void Kangaroo::FetchWalks(uint64_t nbWalk,Int *x,Int *y,Int *d) {
 
 }
 
-void Kangaroo::FetchWalks(uint64_t nbWalk,std::vector<int128_t>& kangs,Int* x,Int* y,Int* d) {
+void Kangaroo::FetchWalks(uint64_t nbWalk,std::vector<int256_t>& kangs,Int* x,Int* y,Int* d) {
 
   uint64_t n = 0;
 
@@ -293,7 +293,7 @@ void Kangaroo::FectchKangaroos(TH_PARAM *threads) {
   double sFetch = Timer::get_tick();
 
   // From server
-  vector<int128_t> kangs;
+  vector<int256_t> kangs;
   if(saveKangarooByServer) {
     ::printf("FectchKangaroosFromServer");
     if(!GetKangaroosFromServer(workFile,kangs))
@@ -492,14 +492,14 @@ void Kangaroo::SaveWork(uint64_t totalCount,double totalTime,TH_PARAM *threads,i
     if(saveKangarooByServer) {
 
       ::printf("\nSaveWork (Kangaroo->Server): %s",fileName.c_str());
-      vector<int128_t> kangs;
+      vector<int256_t> kangs;
       for(int i = 0; i < nbThread; i++)
         totalWalk += threads[i].nbKangaroo;
       kangs.reserve(totalWalk);
 
       for(int i = 0; i < nbThread; i++) {
-        int128_t X;
-        int128_t D;
+        int256_t X;
+        int256_t D;
         uint64_t h;
         for(uint64_t n = 0; n < threads[i].nbKangaroo; n++) {
           HashTable::Convert(&threads[i].px[n],&threads[i].distance[n],n%2,&h,&X,&D);

--- a/GPU/GPUEngine.cu
+++ b/GPU/GPUEngine.cu
@@ -654,7 +654,7 @@ bool GPUEngine::Launch(std::vector<ITEM> &hashFound,bool spinWait) {
     uint32_t *itemPtr = outputItemPinned + (i*ITEM_SIZE32 + 1);
     ITEM it;
 
-    it.kIdx = *((uint64_t*)(itemPtr + 12));
+    it.kIdx = *((uint64_t*)(itemPtr + 16));
 
     uint64_t *x = (uint64_t *)itemPtr;
     it.x.bits64[0] = x[0];
@@ -666,8 +666,8 @@ bool GPUEngine::Launch(std::vector<ITEM> &hashFound,bool spinWait) {
     uint64_t *d = (uint64_t *)(itemPtr + 8);
     it.d.bits64[0] = d[0];
     it.d.bits64[1] = d[1];
-    it.d.bits64[2] = 0;
-    it.d.bits64[3] = 0;
+    it.d.bits64[2] = d[2];
+    it.d.bits64[3] = d[3];
     it.d.bits64[4] = 0;
     if(it.kIdx % 2 == WILD) it.d.ModSubK1order(&wildOffset);
 

--- a/GPU/GPUEngine.h
+++ b/GPU/GPUEngine.h
@@ -28,7 +28,7 @@
 #define KSIZE 10
 #endif
 
-#define ITEM_SIZE   56
+#define ITEM_SIZE   72
 #define ITEM_SIZE32 (ITEM_SIZE/4)
 
 typedef struct {

--- a/GPU/GPUMath.h
+++ b/GPU/GPUMath.h
@@ -183,8 +183,12 @@ out[pos*ITEM_SIZE32 + 9] = ((uint32_t *)d)[0]; \
 out[pos*ITEM_SIZE32 + 10] = ((uint32_t *)d)[1]; \
 out[pos*ITEM_SIZE32 + 11] = ((uint32_t *)d)[2]; \
 out[pos*ITEM_SIZE32 + 12] = ((uint32_t *)d)[3]; \
-out[pos*ITEM_SIZE32 + 13] = ((uint32_t *)idx)[0]; \
-out[pos*ITEM_SIZE32 + 14] = ((uint32_t *)idx)[1]; \
+out[pos*ITEM_SIZE32 + 13] = ((uint32_t *)d)[4]; \
+out[pos*ITEM_SIZE32 + 14] = ((uint32_t *)d)[5]; \
+out[pos*ITEM_SIZE32 + 15] = ((uint32_t *)d)[6]; \
+out[pos*ITEM_SIZE32 + 16] = ((uint32_t *)d)[7]; \
+out[pos*ITEM_SIZE32 + 17] = ((uint32_t *)idx)[0]; \
+out[pos*ITEM_SIZE32 + 18] = ((uint32_t *)idx)[1]; \
 }
 
 // ---------------------------------------------------------------------------------------

--- a/HashTable.cpp
+++ b/HashTable.cpp
@@ -54,13 +54,13 @@ uint64_t HashTable::GetNbItem() {
 
 }
 
-ENTRY *HashTable::CreateEntry(int128_t *x,int128_t *d) {
+ENTRY *HashTable::CreateEntry(int256_t *x,int256_t *d) {
 
   ENTRY *e = (ENTRY *)malloc(sizeof(ENTRY));
-  e->x.i64[0] = x->i64[0];
-  e->x.i64[1] = x->i64[1];
-  e->d.i64[0] = d->i64[0];
-  e->d.i64[1] = d->i64[1];
+  for(int i=0;i<4;i++) {
+    e->x.i64[i] = x->i64[i];
+    e->d.i64[i] = d->i64[i];
+  }
   return e;
 
 }
@@ -72,36 +72,42 @@ ENTRY *HashTable::CreateEntry(int128_t *x,int128_t *d) {
   E[h].items[st] = entry;                  \
   E[h].nbItem++;}
 
-void HashTable::Convert(Int *x,Int *d,uint32_t type,uint64_t *h,int128_t *X,int128_t *D) {
+void HashTable::Convert(Int *x,Int *d,uint32_t type,uint64_t *h,int256_t *X,int256_t *D) {
 
   uint64_t sign = 0;
   uint64_t type64 = (uint64_t)type << 62;
 
   X->i64[0] = x->bits64[0];
   X->i64[1] = x->bits64[1];
+  X->i64[2] = x->bits64[2];
+  X->i64[3] = x->bits64[3];
 
-  // Probability of failure (1/2^128)
-  if(d->bits64[3] > 0x7FFFFFFFFFFFFFFFULL) {
+  // Sign is stored separately
+  if(d->IsNegative()) {
     Int N(d);
     N.ModNegK1order();
     D->i64[0] = N.bits64[0];
-    D->i64[1] = N.bits64[1] & 0x3FFFFFFFFFFFFFFFULL;
+    D->i64[1] = N.bits64[1];
+    D->i64[2] = N.bits64[2];
+    D->i64[3] = N.bits64[3] & 0x3FFFFFFFFFFFFFFFULL;
     sign = 1ULL << 63;
   } else {
     D->i64[0] = d->bits64[0];
-    D->i64[1] = d->bits64[1] & 0x3FFFFFFFFFFFFFFFULL;
+    D->i64[1] = d->bits64[1];
+    D->i64[2] = d->bits64[2];
+    D->i64[3] = d->bits64[3] & 0x3FFFFFFFFFFFFFFFULL;
   }
 
-  D->i64[1] |= sign;
-  D->i64[1] |= type64;
+  D->i64[3] |= sign;
+  D->i64[3] |= type64;
 
   *h = (x->bits64[2] & HASH_MASK);
 
 }
 
 
-#define AV1() if(pnb1) { ::fread(&e1,32,1,f1); pnb1--; }
-#define AV2() if(pnb2) { ::fread(&e2,32,1,f2); pnb2--; }
+#define AV1() if(pnb1) { ::fread(&e1,64,1,f1); pnb1--; }
+#define AV2() if(pnb2) { ::fread(&e2,64,1,f2); pnb2--; }
 
 int HashTable::MergeH(uint32_t h,FILE* f1,FILE* f2,FILE* fd,uint32_t* nbDP,uint32_t *duplicate,Int* d1,uint32_t* k1,Int* d2,uint32_t* k2) {
 
@@ -152,12 +158,13 @@ int HashTable::MergeH(uint32_t h,FILE* f1,FILE* f2,FILE* fd,uint32_t* nbDP,uint3
 
       int comp = compare(&e1.x,&e2.x);
       if(comp < 0) {
-        memcpy(output+nbd,&e1,32);
+        memcpy(output+nbd,&e1,64);
         nbd++;
         AV1();
         nb1--;
       } else if (comp==0) {
-        if((e1.d.i64[0] == e2.d.i64[0]) && (e1.d.i64[1] == e2.d.i64[1])) {
+        if((e1.d.i64[0] == e2.d.i64[0]) && (e1.d.i64[1] == e2.d.i64[1]) &&
+           (e1.d.i64[2] == e2.d.i64[2]) && (e1.d.i64[3] == e2.d.i64[3])) {
           *duplicate = *duplicate + 1;
         } else {
           // Collision
@@ -165,14 +172,14 @@ int HashTable::MergeH(uint32_t h,FILE* f1,FILE* f2,FILE* fd,uint32_t* nbDP,uint3
           CalcDistAndType(e2.d,d2,k2);
           collisionFound = true;
         }
-        memcpy(output + nbd,&e1,32);
+        memcpy(output + nbd,&e1,64);
         nbd++;
         AV1();
         AV2();
         nb1--;
         nb2--;
       } else {
-        memcpy(output + nbd,&e2,32);
+        memcpy(output + nbd,&e2,64);
         nbd++;
         AV2();
         nb2--;
@@ -180,14 +187,14 @@ int HashTable::MergeH(uint32_t h,FILE* f1,FILE* f2,FILE* fd,uint32_t* nbDP,uint3
 
     } else if( !end1 && end2 ) {
 
-      memcpy(output + nbd,&e1,32);
+      memcpy(output + nbd,&e1,64);
       nbd++;
       AV1();
       nb1--;
 
     } else if( end1 && !end2) {
 
-      memcpy(output + nbd,&e2,32);
+      memcpy(output + nbd,&e2,64);
       nbd++;
       AV2();
       nb2--;
@@ -210,7 +217,7 @@ int HashTable::MergeH(uint32_t h,FILE* f1,FILE* f2,FILE* fd,uint32_t* nbDP,uint3
 
   ::fwrite(&nbd,sizeof(uint32_t),1,fd);
   ::fwrite(&md,sizeof(uint32_t),1,fd);
-  ::fwrite(output,32,nbd,fd);
+  ::fwrite(output,64,nbd,fd);
   free(output);
 
   *nbDP = nbd;
@@ -220,8 +227,8 @@ int HashTable::MergeH(uint32_t h,FILE* f1,FILE* f2,FILE* fd,uint32_t* nbDP,uint3
 
 int HashTable::Add(Int *x,Int *d,uint32_t type) {
 
-  int128_t X;
-  int128_t D;
+  int256_t X;
+  int256_t D;
   uint64_t h;
   Convert(x,d,type,&h,&X,&D);
   ENTRY* e = CreateEntry(&X,&D);
@@ -239,22 +246,24 @@ void HashTable::ReAllocate(uint64_t h,uint32_t add) {
 
 }
 
-int HashTable::Add(uint64_t h,int128_t *x,int128_t *d) {
+int HashTable::Add(uint64_t h,int256_t *x,int256_t *d) {
 
   ENTRY *e = CreateEntry(x,d);
   return Add(h,e);
 
 }
 
-void HashTable::CalcDistAndType(int128_t d,Int* kDist,uint32_t* kType) {
+void HashTable::CalcDistAndType(int256_t d,Int* kDist,uint32_t* kType) {
 
-  *kType = (d.i64[1] & 0x4000000000000000ULL) != 0;
-  int sign = (d.i64[1] & 0x8000000000000000ULL) != 0;
-  d.i64[1] &= 0x3FFFFFFFFFFFFFFFULL;
+  *kType = (d.i64[3] & 0x4000000000000000ULL) != 0;
+  int sign = (d.i64[3] & 0x8000000000000000ULL) != 0;
+  d.i64[3] &= 0x3FFFFFFFFFFFFFFFULL;
 
   kDist->SetInt32(0);
   kDist->bits64[0] = d.i64[0];
   kDist->bits64[1] = d.i64[1];
+  kDist->bits64[2] = d.i64[2];
+  kDist->bits64[3] = d.i64[3];
   if(sign) kDist->ModNegK1order();
 
 }
@@ -287,7 +296,10 @@ int HashTable::Add(uint64_t h,ENTRY* e) {
       ed = mi - 1;
     } else if (comp==0) {
 
-      if((e->d.i64[0] == GET(h,mi)->d.i64[0]) && (e->d.i64[1] == GET(h,mi)->d.i64[1])) {
+      if((e->d.i64[0] == GET(h,mi)->d.i64[0]) &&
+         (e->d.i64[1] == GET(h,mi)->d.i64[1]) &&
+         (e->d.i64[2] == GET(h,mi)->d.i64[2]) &&
+         (e->d.i64[3] == GET(h,mi)->d.i64[3])) {
         // Same point added 2 times or collision in same herd !
         return ADD_DUPLICATE;
       }
@@ -306,20 +318,17 @@ int HashTable::Add(uint64_t h,ENTRY* e) {
 
 }
 
-int HashTable::compare(int128_t *i1,int128_t *i2) {
+int HashTable::compare(int256_t *i1,int256_t *i2) {
 
   uint64_t *a = i1->i64;
   uint64_t *b = i2->i64;
 
-  if(a[1] == b[1]) {
-    if(a[0] == b[0]) {
-      return 0;
-    } else {
-      return (a[0] > b[0]) ? 1 : -1;
+  for(int i=3;i>=0;i--) {
+    if(a[i] != b[i]) {
+      return (a[i] > b[i]) ? 1 : -1;
     }
-  } else {
-    return (a[1] > b[1]) ? 1 : -1;
   }
+  return 0;
 
 }
 
@@ -356,12 +365,12 @@ std::string HashTable::GetSizeInfo() {
 
 }
 
-std::string HashTable::GetStr(int128_t *i) {
+std::string HashTable::GetStr(int256_t *i) {
 
   std::string ret;
   char tmp[256];
-  for(int n=3;n>=0;n--) {
-    ::sprintf(tmp,"%08X",i->i32[n]); 
+  for(int n=7;n>=0;n--) {
+    ::sprintf(tmp,"%08X",i->i32[n]);
     ret += std::string(tmp);
   }
   return ret;
@@ -381,8 +390,8 @@ void HashTable::SaveTable(FILE* f,uint32_t from,uint32_t to,bool printPoint) {
     fwrite(&E[h].nbItem,sizeof(uint32_t),1,f);
     fwrite(&E[h].maxItem,sizeof(uint32_t),1,f);
     for(uint32_t i = 0; i < E[h].nbItem; i++) {
-      fwrite(&(E[h].items[i]->x),16,1,f);
-      fwrite(&(E[h].items[i]->d),16,1,f);
+      fwrite(&(E[h].items[i]->x),32,1,f);
+      fwrite(&(E[h].items[i]->d),32,1,f);
       if(printPoint) {
         pointPrint++;
         if(pointPrint > point) {
@@ -425,7 +434,7 @@ void HashTable::SeekNbItem(FILE* f,uint32_t from,uint32_t to) {
     fread(&E[h].nbItem,sizeof(uint32_t),1,f);
     fread(&E[h].maxItem,sizeof(uint32_t),1,f);
 
-    uint64_t hSize = 32ULL * E[h].nbItem;
+    uint64_t hSize = 64ULL * E[h].nbItem;
 #ifdef WIN64
     _fseeki64(f,hSize,SEEK_CUR);
 #else
@@ -451,8 +460,8 @@ void HashTable::LoadTable(FILE* f,uint32_t from,uint32_t to) {
 
     for(uint32_t i = 0; i < E[h].nbItem; i++) {
       ENTRY* e = (ENTRY*)malloc(sizeof(ENTRY));
-      fread(&(e->x),16,1,f);
-      fread(&(e->d),16,1,f);
+      fread(&(e->x),32,1,f);
+      fread(&(e->d),32,1,f);
       E[h].items[i] = e;
     }
 

--- a/HashTable.h
+++ b/HashTable.h
@@ -33,25 +33,24 @@
 #define ADD_DUPLICATE 1
 #define ADD_COLLISION 2
 
-union int128_s {
-
-  uint8_t  i8[16];
-  uint16_t i16[8];
-  uint32_t i32[4];
-  uint64_t i64[2];
-
+union int256_s {
+  uint8_t  i8[32];
+  uint16_t i16[16];
+  uint32_t i32[8];
+  uint64_t i64[4];
 };
 
-typedef union int128_s int128_t;
+typedef union int256_s int256_t;
 
 #define safe_free(x) if(x) {free(x);x=NULL;}
 
-// We store only 128 (+18) bit a the x value which give a probabilty a wrong collision after 2^73 entries
+// X and distance are stored on 256 bits
+// Distance layout: b255=sign, b254=kangaroo type, b253..b0=distance
 
 typedef struct {
 
-  int128_t  x;    // Poisition of kangaroo (128bit LSB)
-  int128_t  d;    // Travelled distance (b127=sign b126=kangaroo type, b125..b0 distance
+  int256_t  x;    // Position of kangaroo (256-bit)
+  int256_t  d;    // Travelled distance
 
 } ENTRY;
 
@@ -69,7 +68,7 @@ public:
 
   HashTable();
   int Add(Int *x,Int *d,uint32_t type);
-  int Add(uint64_t h,int128_t *x,int128_t *d);
+  int Add(uint64_t h,int256_t *x,int256_t *d);
   int Add(uint64_t h,ENTRY *e);
   uint64_t GetNbItem();
   void Reset();
@@ -88,16 +87,16 @@ public:
   Int      kDist;
   uint32_t kType;
 
-  static void Convert(Int *x,Int *d,uint32_t type,uint64_t *h,int128_t *X,int128_t *D);
+  static void Convert(Int *x,Int *d,uint32_t type,uint64_t *h,int256_t *X,int256_t *D);
   static int MergeH(uint32_t h,FILE* f1,FILE* f2,FILE* fd,uint32_t *nbDP,uint32_t* duplicate,
                     Int* d1,uint32_t* k1,Int* d2,uint32_t* k2);
-  static void CalcDistAndType(int128_t d,Int* kDist,uint32_t* kType);
+  static void CalcDistAndType(int256_t d,Int* kDist,uint32_t* kType);
 
 private:
 
-  ENTRY *CreateEntry(int128_t *x,int128_t *d);
-  static int compare(int128_t *i1,int128_t *i2);
-  std::string GetStr(int128_t *i);
+  ENTRY *CreateEntry(int256_t *x,int256_t *d);
+  static int compare(int256_t *i1,int256_t *i2);
+  std::string GetStr(int256_t *i);
 
 };
 

--- a/Kangaroo.cpp
+++ b/Kangaroo.cpp
@@ -313,7 +313,7 @@ bool Kangaroo::AddToTable(Int *pos,Int *dist,uint32_t kType) {
 
 }
 
-bool Kangaroo::AddToTable(uint64_t h,int128_t *x,int128_t *d) {
+bool Kangaroo::AddToTable(uint64_t h,int256_t *x,int256_t *d) {
 
   int addStatus = hashTable.Add(h,x,d);
   if(addStatus== ADD_COLLISION) {
@@ -747,7 +747,7 @@ void Kangaroo::CreateJumpTable() {
   int jumpBit = rangePower / 2 + 1;
 #endif
 
-  if(jumpBit > 128) jumpBit = 128;
+  if(jumpBit > 256) jumpBit = 256;
   int maxRetry = 100;
   bool ok = false;
   double distAvg;

--- a/Kangaroo.h
+++ b/Kangaroo.h
@@ -95,8 +95,8 @@ typedef struct {
 
   uint32_t kIdx;
   uint32_t h;
-  int128_t x;
-  int128_t d;
+  int256_t x;
+  int256_t d;
 
 } DP;
 
@@ -165,7 +165,7 @@ private:
   void SetDP(int size);
   void CreateHerd(int nbKangaroo,Int *px, Int *py, Int *d, int firstType,bool lock=true);
   void CreateJumpTable();
-  bool AddToTable(uint64_t h,int128_t *x,int128_t *d);
+  bool AddToTable(uint64_t h,int256_t *x,int256_t *d);
   bool AddToTable(Int *pos,Int *dist,uint32_t kType);
   bool SendToServer(std::vector<ITEM> &dp,uint32_t threadId,uint32_t gpuId);
   bool CheckKey(Int d1,Int d2,uint8_t type);
@@ -181,7 +181,7 @@ private:
   void SaveWork(uint64_t totalCount,double totalTime,TH_PARAM *threads,int nbThread);
   void SaveServerWork();
   void FetchWalks(uint64_t nbWalk,Int *x,Int *y,Int *d);
-  void FetchWalks(uint64_t nbWalk,std::vector<int128_t>& kangs,Int* x,Int* y,Int* d);
+  void FetchWalks(uint64_t nbWalk,std::vector<int256_t>& kangs,Int* x,Int* y,Int* d);
   void FectchKangaroos(TH_PARAM *threads);
   FILE *ReadHeader(std::string fileName,uint32_t *version,int type);
   bool  SaveHeader(std::string fileName,FILE* f,int type,uint64_t totalCount,double totalTime);
@@ -204,8 +204,8 @@ private:
   void InitSocket();
   void WaitForServer();
   int32_t GetServerStatus();
-  bool SendKangaroosToServer(std::string& fileName,std::vector<int128_t>& kangs);
-  bool GetKangaroosFromServer(std::string& fileName,std::vector<int128_t>& kangs);
+  bool SendKangaroosToServer(std::string& fileName,std::vector<int256_t>& kangs);
+  bool GetKangaroosFromServer(std::string& fileName,std::vector<int256_t>& kangs);
 
 #ifdef WIN64
   HANDLE ghMutex;

--- a/Network.cpp
+++ b/Network.cpp
@@ -336,7 +336,7 @@ bool Kangaroo::HandleRequest(TH_PARAM *p) {
       uint64_t nbKangaroo = 0;
       uint32_t strSize;
       char fileName[256];
-      int128_t* KBuff;
+      int256_t* KBuff;
       uint32_t nbK;
       uint32_t header = HEADKS;
       uint32_t version = 0;
@@ -378,7 +378,7 @@ bool Kangaroo::HandleRequest(TH_PARAM *p) {
       PUT("nbKangaroo",p->clientSock,&nbKangaroo,sizeof(uint64_t),ntimeout);
 
       checkSum.SetInt32(0);
-      KBuff = (int128_t*)malloc(KANG_PER_BLOCK * sizeof(int128_t));
+      KBuff = (int256_t*)malloc(KANG_PER_BLOCK * sizeof(int256_t));
 
       while(nbKangaroo > 0) {
 
@@ -389,7 +389,7 @@ bool Kangaroo::HandleRequest(TH_PARAM *p) {
         }
 
         for(uint32_t k = 0; k < nbK; k++) {
-          ::fread(&KBuff[k],16,1,f);
+          ::fread(&KBuff[k],32,1,f);
           // Checksum
           K.SetInt32(0);
           K.bits64[1] = KBuff[k].i64[1];
@@ -397,7 +397,7 @@ bool Kangaroo::HandleRequest(TH_PARAM *p) {
           checkSum.Add(&K);
         }
 
-        PUTFREE("packet",p->clientSock,KBuff,nbK * 16,ntimeout,KBuff);
+        PUTFREE("packet",p->clientSock,KBuff,nbK * 32,ntimeout,KBuff);
 
         nbKangaroo -= nbK;
 
@@ -422,7 +422,7 @@ bool Kangaroo::HandleRequest(TH_PARAM *p) {
       uint32_t fileNameSize;
       char fileNameTmp[264];
       char fileName[256];
-      int128_t *KBuff;
+      int256_t *KBuff;
       uint32_t nbK;
       uint32_t header = HEADKS;
       uint32_t version = 0;
@@ -459,7 +459,7 @@ bool Kangaroo::HandleRequest(TH_PARAM *p) {
 
       checkSum.SetInt32(0);
 
-      KBuff = (int128_t *)malloc(KANG_PER_BLOCK*sizeof(int128_t));
+      KBuff = (int256_t *)malloc(KANG_PER_BLOCK*sizeof(int256_t));
 
       while(nbKangaroo>0) {
 
@@ -469,10 +469,10 @@ bool Kangaroo::HandleRequest(TH_PARAM *p) {
           nbK = (uint32_t)nbKangaroo;
         }
 
-        GETFREE("packet",p->clientSock,KBuff,nbK * 16,ntimeout,KBuff);
+        GETFREE("packet",p->clientSock,KBuff,nbK * 32,ntimeout,KBuff);
 
         for(uint32_t k = 0; k < nbK; k++) {
-          ::fwrite(&KBuff[k],16,1,f);
+          ::fwrite(&KBuff[k],32,1,f);
           // Checksum
           K.SetInt32(0);
           K.bits64[1] = KBuff[k].i64[1];
@@ -566,7 +566,11 @@ bool Kangaroo::HandleRequest(TH_PARAM *p) {
               P = secp->AddDirect(keyToSearch,P);
 
             uint32_t hC = P.x.bits64[2] & HASH_MASK;
-            bool ok = (hC == h) && (P.x.bits64[0] == dp[i].x.i64[0]) && (P.x.bits64[1] == dp[i].x.i64[1]);
+            bool ok = (hC == h) &&
+                      (P.x.bits64[0] == dp[i].x.i64[0]) &&
+                      (P.x.bits64[1] == dp[i].x.i64[1]) &&
+                      (P.x.bits64[2] == dp[i].x.i64[2]) &&
+                      (P.x.bits64[3] == dp[i].x.i64[3]);
             if(!ok) {
               if(kType==TAME) {
                 ::printf("\nWrong TAME point from: %s [dp=%d PID=%u thId=%u gpuId=%u]\n",p->clientInfo,i,
@@ -696,7 +700,7 @@ void Kangaroo::RunServer() {
   }
   SetDP(initDPSize);
 
-  if(sizeof(DP) != 40) {
+  if(sizeof(DP) != 72) {
     ::printf("Error: Invalid DP size struct\n");
     exit(-1);
   }
@@ -980,14 +984,14 @@ void Kangaroo::WaitForServer() {
 }
 
 // Get Kangaroo from server
-bool Kangaroo::GetKangaroosFromServer(std::string& fileName,std::vector<int128_t>& kangs) {
+bool Kangaroo::GetKangaroosFromServer(std::string& fileName,std::vector<int256_t>& kangs) {
 
   int nbRead;
   int nbWrite;
   uint32_t fileNameSize = (uint32_t)fileName.length();
   uint64_t nbKangaroo = 0;
   uint32_t nbK;
-  int128_t* KBuff;
+  int256_t* KBuff;
   Int checkSum;
 
   WaitForServer();
@@ -1011,7 +1015,7 @@ bool Kangaroo::GetKangaroosFromServer(std::string& fileName,std::vector<int128_t
     uint64_t point = (nbKangaroo / KANG_PER_BLOCK) / 32;
     uint64_t pointPrint = 0;
 
-    KBuff = (int128_t*)malloc(KANG_PER_BLOCK * sizeof(int128_t));
+    KBuff = (int256_t*)malloc(KANG_PER_BLOCK * sizeof(int256_t));
     kangs.reserve(nbKangaroo);
 
     checkSum.SetInt32(0);
@@ -1029,7 +1033,7 @@ bool Kangaroo::GetKangaroosFromServer(std::string& fileName,std::vector<int128_t
         nbK = (uint32_t)nbKangaroo;
       }
 
-      GETFREE("packet",serverConn,KBuff,nbK * 16,ntimeout,KBuff);
+      GETFREE("packet",serverConn,KBuff,nbK * 32,ntimeout,KBuff);
 
       for(uint32_t k = 0; k < nbK; k++) {
         kangs.push_back(KBuff[k]);
@@ -1064,19 +1068,19 @@ bool Kangaroo::GetKangaroosFromServer(std::string& fileName,std::vector<int128_t
 }
 
 // Send Kangaroo to Server
-bool Kangaroo::SendKangaroosToServer(std::string& fileName,std::vector<int128_t>& kangs) {
+bool Kangaroo::SendKangaroosToServer(std::string& fileName,std::vector<int256_t>& kangs) {
 
   int nbWrite;
   uint32_t fileNameSize = (uint32_t)fileName.length();
   uint64_t nbKangaroo = kangs.size();
   uint64_t pos;
   uint32_t nbK;
-  int128_t *KBuff;
+  int256_t *KBuff;
   Int checkSum;
 
   WaitForServer();
 
-  uint64_t point = (nbKangaroo/KANG_PER_BLOCK) / 16;
+  uint64_t point = (nbKangaroo/KANG_PER_BLOCK) / 32;
   uint64_t pointPrint = 0;
 
   if(!endOfSearch) {
@@ -1088,7 +1092,7 @@ bool Kangaroo::SendKangaroosToServer(std::string& fileName,std::vector<int128_t>
     PUT("fileName",serverConn,fileName.c_str(),fileNameSize,ntimeout);
     PUT("nbKangaroo",serverConn,&nbKangaroo,sizeof(uint64_t),ntimeout);
 
-    KBuff = (int128_t*)malloc(KANG_PER_BLOCK * sizeof(int128_t));
+    KBuff = (int256_t*)malloc(KANG_PER_BLOCK * sizeof(int256_t));
 
     checkSum.SetInt32(0);
     pos = 0;
@@ -1107,7 +1111,7 @@ bool Kangaroo::SendKangaroosToServer(std::string& fileName,std::vector<int128_t>
       }
 
       for(uint32_t k = 0; k < nbK; k++) {
-        memcpy(&KBuff[k],&kangs[pos],16);
+        memcpy(&KBuff[k],&kangs[pos],32);
         pos++;
         // Checksum
         Int K;
@@ -1117,7 +1121,7 @@ bool Kangaroo::SendKangaroosToServer(std::string& fileName,std::vector<int128_t>
         checkSum.Add(&K);
       }
 
-      PUTFREE("packet",serverConn,KBuff,nbK * 16,ntimeout,KBuff);
+      PUTFREE("packet",serverConn,KBuff,nbK * 32,ntimeout,KBuff);
 
       nbKangaroo -= nbK;
 
@@ -1153,17 +1157,17 @@ bool Kangaroo::SendToServer(std::vector<ITEM> &dps,uint32_t threadId,uint32_t gp
     DP *dp = (DP *)malloc(sizeof(DP)*nbDP);
     for(uint32_t i = 0; i<nbDP; i++) {
 
-      int128_t X;
-      int128_t D;
+      int256_t X;
+      int256_t D;
       uint64_t h;
       HashTable::Convert(&dps[i].x,&dps[i].d,dps[i].kIdx % 2,&h,&X,&D);
 
       dp[i].kIdx = (uint32_t)dps[i].kIdx;
       dp[i].h = (uint32_t)h;
-      dp[i].x.i64[0] = X.i64[0];
-      dp[i].x.i64[1] = X.i64[1];
-      dp[i].d.i64[0] = D.i64[0];
-      dp[i].d.i64[1] = D.i64[1];
+      for(int j=0;j<4;j++) {
+        dp[i].x.i64[j] = X.i64[j];
+        dp[i].d.i64[j] = D.i64[j];
+      }
 
     }
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pollard's kangaroo for SECPK1
 
 A Pollard's kangaroo interval ECDLP solver for SECP256K1 (based on VanitySearch engine).\
-**This program is limited to a 125bit interval search.**
+Supports intervals up to roughly 2^254.
 
 # Feature
 

--- a/Timer.cpp
+++ b/Timer.cpp
@@ -31,6 +31,7 @@ LARGE_INTEGER Timer::qwTicksPerSec;
 #include <sys/time.h>
 #include <unistd.h>
 #include <string.h>
+#include <cstdint>
 time_t Timer::tickStart;
 
 #endif

--- a/Timer.h
+++ b/Timer.h
@@ -20,6 +20,7 @@
 
 #include <time.h>
 #include <string>
+#include <cstdint>
 #ifdef WIN64
 #include <windows.h>
 #endif


### PR DESCRIPTION
## Summary
- use new `int256_t` type for hash table entries and network packets
- update GPU item layout and constants
- remove 128-bit jump limit
- document 254‑bit interval support in README
- include `<cstdint>` in Timer
